### PR TITLE
get-diff command + local manifest store

### DIFF
--- a/cmd/commands/get_blueprints.go
+++ b/cmd/commands/get_blueprints.go
@@ -42,7 +42,7 @@ func NewGetBlueprintsCommand() *cobra.Command {
 				return err
 			}
 
-			blueprints.PrintCounts(cmd.OutOrStdout(), counts, includeEmpty)
+			blueprints.PrintCounts(cmd.OutOrStdout(), counts, includeEmpty, false)
 
 			return nil
 		},

--- a/cmd/commands/get_diff.go
+++ b/cmd/commands/get_diff.go
@@ -2,10 +2,14 @@ package commands
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 
-	"github.com/spf13/cobra"
 	"github.com/port-labs/port-github-migrator/internal/diff"
 	"github.com/port-labs/port-github-migrator/internal/port"
+	"github.com/port-labs/port-github-migrator/internal/store"
+	"github.com/spf13/cobra"
 )
 
 func NewGetDiffCommand() *cobra.Command {
@@ -28,6 +32,7 @@ func NewGetDiffCommand() *cobra.Command {
 			newInstallID, _ := cmd.Flags().GetString("new-installation-id")
 			showDiffs, _ := cmd.Flags().GetBool("show-diffs")
 			limitStr, _ := cmd.Flags().GetString("limit")
+			outputPath, _ := cmd.Flags().GetString("output")
 
 			sourceBlueprint := args[0]
 			targetBlueprint := args[1]
@@ -63,17 +68,31 @@ func NewGetDiffCommand() *cobra.Command {
 			diffService := diff.NewService(client)
 
 			// Run comparison
-			result, err := diffService.CompareBlueprints(sourceBlueprint, targetBlueprint, oldInstallID, newInstallID)
+			result, err := diffService.CompareBlueprints(sourceBlueprint, targetBlueprint, oldInstallID, newInstallID, cmd.ErrOrStderr())
 			if err != nil {
 				return fmt.Errorf("failed to compare blueprints: %w", err)
 			}
 
-			// Print summary
-			diffService.PrintSummary(result)
+			out, closeOut, err := openDiffOutput(outputPath)
+			if err != nil {
+				return fmt.Errorf("failed to open output file: %w", err)
+			}
+			defer closeOut()
 
-			// Show detailed diffs if enabled
-			if showDiffs && len(result.Changes) > 0 {
-				diffService.PrintDetailedDiffs(result.Changes, limit)
+			diffService.PrintSummary(out, result)
+
+			if showDiffs && (len(result.Changed) > 0 || len(result.NotMigrated) > 0) {
+				diffService.PrintDetailedDiffs(out, result, limit)
+			}
+
+			if outputPath != "" {
+				fmt.Fprintf(cmd.OutOrStderr(), "📝 Wrote diff to %s\n", outputPath)
+			}
+
+			if st, err := store.Open(); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "⚠️  Could not open local cache, identifiers not saved: %v\n", err)
+			} else if _, err := st.SaveIdentifiers(oldInstallID, sourceBlueprint, result.SourceIdentifiers); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "⚠️  Failed to save identifiers: %v\n", err)
 			}
 
 			return nil
@@ -82,6 +101,25 @@ func NewGetDiffCommand() *cobra.Command {
 
 	cmd.Flags().Bool("show-diffs", true, "Show detailed property differences")
 	cmd.Flags().String("limit", "10", "Limit number of shown changes")
+	cmd.Flags().StringP("output", "o", "", "Write the diff to this file instead of stdout")
 
 	return cmd
+}
+
+func openDiffOutput(path string) (io.Writer, func(), error) {
+	if path == "" {
+		return os.Stdout, func() {}, nil
+	}
+
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() { _ = f.Close() }, nil
 }

--- a/cmd/commands/migrate.go
+++ b/cmd/commands/migrate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/port-labs/port-github-migrator/internal/migrator"
 	"github.com/port-labs/port-github-migrator/internal/models"
 	"github.com/port-labs/port-github-migrator/internal/port"
+	"github.com/port-labs/port-github-migrator/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,11 @@ func NewMigrateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "migrate [blueprint]",
 		Short:        "Migrate Ownership of entities from a specific blueprint or all blueprints",
-		Long:         `Migrate Ownership of entities from the old GitHub App integration to the new GitHub Ocean integration.`,
+		Long: `Migrate Ownership of entities from the old GitHub App integration to the new GitHub Ocean integration.
+
+When run for a single blueprint, migrate honors the manifest produced by
+'get-diff' if one exists for the same old installation: it patches exactly
+those identifiers and removes the manifest on success.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			portURL, _ := cmd.Flags().GetString("port-url")
@@ -56,8 +61,6 @@ func NewMigrateCommand() *cobra.Command {
 
 			client := port.NewClient(portURL, clientID, clientSecret)
 
-			// Fetch the new integration. We need its version for the datasource id
-			// and its config for the entityDeletionThreshold safety check.
 			intg, err := client.GetIntegration(newInstallID)
 			if err != nil {
 				return fmt.Errorf("failed to get integration: %w", err)
@@ -80,7 +83,14 @@ func NewMigrateCommand() *cobra.Command {
 				NewInstallationID: newInstallID,
 			}
 
-			mig := migrator.NewMigrator(client, config)
+			// Open the local manifest store; if it can't be opened we still
+			// migrate, just without the get-diff manifest contract.
+			st, storeErr := store.Open()
+			if storeErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "⚠️  Could not open local cache, manifests will be ignored: %v\n", storeErr)
+			}
+
+			mig := migrator.NewMigrator(client, config, st)
 
 			if all {
 				fmt.Fprintln(cmd.OutOrStdout(), "📋 Blueprints to migrate:")
@@ -89,7 +99,7 @@ func NewMigrateCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				blueprints.PrintCounts(cmd.OutOrStdout(), counts, false)
+				blueprints.PrintCounts(cmd.OutOrStdout(), counts, false, true)
 				fmt.Fprintln(cmd.OutOrStdout())
 			}
 

--- a/internal/blueprints/counts.go
+++ b/internal/blueprints/counts.go
@@ -102,7 +102,9 @@ func FetchCounts(client *port.Client, oldInstallID string, spinnerOut io.Writer)
 
 // PrintCounts renders the standard NAME / ENTITIES table.
 // When includeEmpty is false, blueprints with 0 entities are omitted.
-func PrintCounts(w io.Writer, counts []Count, includeEmpty bool) {
+// When showCap is true, blueprints whose count exceeds port.MaxSearchResults
+// are rendered as "capped / total" to surface the per-blueprint fetch limit.
+func PrintCounts(w io.Writer, counts []Count, includeEmpty, showCap bool) {
 	fmt.Fprintln(w, "NAME                              ENTITIES")
 	fmt.Fprintln(w, "──────────────────────────────────────────")
 	for _, r := range counts {
@@ -113,6 +115,10 @@ func PrintCounts(w io.Writer, counts []Count, includeEmpty bool) {
 		if r.Count == 0 && !includeEmpty {
 			continue
 		}
-		fmt.Fprintf(w, "%-33s %d\n", r.Name, r.Count)
+		if showCap && r.Count > port.MaxSearchResults {
+			fmt.Fprintf(w, "%-33s %d / %d\n", r.Name, port.MaxSearchResults, r.Count)
+		} else {
+			fmt.Fprintf(w, "%-33s %d\n", r.Name, r.Count)
+		}
 	}
 }

--- a/internal/diff/service.go
+++ b/internal/diff/service.go
@@ -1,10 +1,13 @@
 package diff
 
 import (
-	"encoding/json"
 	"fmt"
+	"io"
 	"reflect"
+	"sync"
+	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/port-labs/port-github-migrator/internal/models"
 	"github.com/port-labs/port-github-migrator/internal/port"
 )
@@ -19,173 +22,250 @@ func NewService(client *port.Client) *Service {
 	return &Service{client: client}
 }
 
-// CompareBlueprints compares entities between source and target blueprints
-func (s *Service) CompareBlueprints(sourceBP, targetBP, oldInstallID, newInstallID string) (*models.DiffResult, error) {
-	// Get source entities (old installation)
-	sourceEntities, err := s.client.SearchOldEntitiesByBlueprint(sourceBP, oldInstallID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get source entities: %w", err)
+// CompareBlueprints compares entities between source and target blueprints.
+// Source and target searches run concurrently. A spinner is rendered to
+// spinnerOut while the requests are in flight; pass io.Discard to disable it.
+func (s *Service) CompareBlueprints(sourceBP, targetBP, oldInstallID, newInstallID string, spinnerOut io.Writer) (*models.DiffResult, error) {
+	sp := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	sp.Writer = spinnerOut
+	sp.HideCursor = true
+
+	var (
+		progressMu sync.Mutex
+		fetched    int
+	)
+	setFetchSuffix := func() {
+		sp.Lock()
+		sp.Suffix = fmt.Sprintf(" Fetching entities for %s and %s (%d/2)", sourceBP, targetBP, fetched)
+		sp.Unlock()
+	}
+	setDiffSuffix := func() {
+		sp.Lock()
+		sp.Suffix = fmt.Sprintf(" Performing diff between %s and %s", sourceBP, targetBP)
+		sp.Unlock()
+	}
+	setFetchSuffix()
+	sp.Start()
+	defer sp.Stop()
+
+	var (
+		sourceEntities []port.Entity
+		targetEntities []port.Entity
+		sourceTotal    int
+		sourceErr      error
+		targetErr      error
+		sourceCountErr error
+		wg             sync.WaitGroup
+	)
+
+	tickFetched := func() {
+		progressMu.Lock()
+		fetched++
+		setFetchSuffix()
+		progressMu.Unlock()
 	}
 
-	// Get target entities (new installation)
-	targetEntities, err := s.client.SearchNewEntitiesByBlueprint(targetBP, newInstallID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get target entities: %w", err)
+	// The target search must filter by the source identifiers, so it depends
+	// on the source search completing first. The source count call runs
+	// independently alongside both searches. We don't count the target side:
+	// it's just a reference oracle for the diff, so its overall size is
+	// irrelevant to migration.
+	sourceDone := make(chan struct{})
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		defer close(sourceDone)
+		sourceEntities, sourceErr = s.client.SearchOldEntitiesByBlueprint(sourceBP, oldInstallID, nil)
+		tickFetched()
+	}()
+	go func() {
+		defer wg.Done()
+		<-sourceDone
+		if sourceErr != nil {
+			return
+		}
+		identifiers := make([]string, len(sourceEntities))
+		for i, e := range sourceEntities {
+			identifiers[i] = e.Identifier
+		}
+		targetEntities, targetErr = s.client.SearchNewEntitiesByBlueprint(targetBP, newInstallID, identifiers, nil)
+		tickFetched()
+	}()
+	go func() {
+		defer wg.Done()
+		sourceTotal, sourceCountErr = s.client.CountOldEntitiesByBlueprint(sourceBP, oldInstallID)
+	}()
+	wg.Wait()
+
+	if sourceErr != nil {
+		return nil, fmt.Errorf("failed to get source entities: %w", sourceErr)
+	}
+	if targetErr != nil {
+		return nil, fmt.Errorf("failed to get target entities: %w", targetErr)
+	}
+	if sourceCountErr != nil {
+		return nil, fmt.Errorf("failed to count source entities: %w", sourceCountErr)
 	}
 
-	// Index entities
-	sourceMap := make(map[string]port.Entity)
-	targetMap := make(map[string]port.Entity)
+	setDiffSuffix()
 
+	identical, changed, notMigrated := DiffEntities(sourceEntities, targetEntities)
+
+	sourceIdentifiers := make([]string, 0, len(sourceEntities))
 	for _, e := range sourceEntities {
-		sourceMap[e.Identifier] = e
+		sourceIdentifiers = append(sourceIdentifiers, e.Identifier)
 	}
 
-	for _, e := range targetEntities {
+	return &models.DiffResult{
+		SourceBlueprint:   sourceBP,
+		TargetBlueprint:   targetBP,
+		SourceTotal:       sourceTotal,
+		SourceIdentifiers: sourceIdentifiers,
+		SourceCompared:    len(sourceEntities),
+		Changed:           changed,
+		NotMigrated:       notMigrated,
+		Summary: models.DiffSummary{
+			Identical:   len(identical),
+			Changed:     len(changed),
+			NotMigrated: len(notMigrated),
+		},
+	}, nil
+}
+
+// DiffEntities compares one batch of source entities to the target entities
+// fetched for them. It returns three disjoint slices so callers can act on
+// them directly without re-discriminating by type:
+//
+//   - identical:  identifiers that match on both sides
+//   - changed:    EntityChange values carrying the per-property diffs
+//   - notMigrated: identifiers present on the source but missing from the target
+func DiffEntities(source, target []port.Entity) (identical []string, changed []models.EntityChange, notMigrated []string) {
+	targetMap := make(map[string]port.Entity, len(target))
+	for _, e := range target {
 		targetMap[e.Identifier] = e
 	}
 
-	// Compare entities
-	result := &models.DiffResult{
-		SourceBlueprint: sourceBP,
-		TargetBlueprint: targetBP,
-		Changes:         []models.EntityChange{},
-	}
+	identical = make([]string, 0, len(source))
+	changed = make([]models.EntityChange, 0)
+	notMigrated = make([]string, 0)
 
-	excludedProps := map[string]bool{
-		"blueprint": true,
-		"createdAt": true,
-		"updatedAt": true,
-		"createdBy": true,
-		"updatedBy": true,
-	}
-
-	// Check common entities
-	for id, sourceEntity := range sourceMap {
-		if targetEntity, exists := targetMap[id]; exists {
-			// Entity exists in both
-			if entitiesEqual(sourceEntity, targetEntity, excludedProps) {
-				result.Summary.Identical++
-			} else {
-				result.Summary.Changed++
-				change := models.EntityChange{
-					Identifier: id,
-					Type:       "changed",
-					PropertyDiffs: getPropertyDiffs(sourceEntity, targetEntity, excludedProps),
-				}
-				result.Changes = append(result.Changes, change)
-			}
-		} else {
-			// Entity only in source (not migrated)
-			result.Summary.NotMigrated++
-			change := models.EntityChange{
-				Identifier: id,
-				Type:       "notMigrated",
-				OldEntity:  entityToMap(sourceEntity),
-			}
-			result.Changes = append(result.Changes, change)
+	for _, sourceEntity := range source {
+		id := sourceEntity.Identifier
+		targetEntity, exists := targetMap[id]
+		if !exists {
+			notMigrated = append(notMigrated, id)
+			continue
 		}
-	}
-
-	// Check for orphaned entities (only in target)
-	for id := range targetMap {
-		if _, exists := sourceMap[id]; !exists {
-			result.Summary.Orphaned++
-			change := models.EntityChange{
-				Identifier: id,
-				Type:       "orphaned",
-			}
-			result.Changes = append(result.Changes, change)
+		if entitiesEqual(sourceEntity, targetEntity) {
+			identical = append(identical, id)
+			continue
 		}
+		changed = append(changed, models.EntityChange{
+			Identifier:    id,
+			PropertyDiffs: getPropertyDiffs(sourceEntity, targetEntity),
+		})
 	}
 
-	return result, nil
+	return identical, changed, notMigrated
 }
 
-// PrintSummary prints the diff summary with entity identifiers
-func (s *Service) PrintSummary(result *models.DiffResult) {
-	fmt.Println()
-	fmt.Printf("📊 %s (old) → %s (new)\n", result.SourceBlueprint, result.TargetBlueprint)
-	fmt.Println("   " + repeatString("─", 40))
-	fmt.Printf("   ✅ %d identical\n", result.Summary.Identical)
+// PrintSummary writes the diff summary with entity identifiers to w. The
+// only "capped" warning that fires is on the source side, and only when the
+// 5000-result cap actually truncated the source set — the target blueprint
+// is just a reference oracle for the diff, so its overall size is not
+// reported.
+func (s *Service) PrintSummary(w io.Writer, result *models.DiffResult) {
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "📊 %s (old) → %s (new)\n", result.SourceBlueprint, result.TargetBlueprint)
+	fmt.Fprintln(w, "   "+repeatString("─", 40))
+	if result.SourceTotal > port.MaxSearchResults {
+		fmt.Fprintf(w, "   ⚠️  source: compared %d / %d (capped at %d)\n",
+			result.SourceCompared, result.SourceTotal, port.MaxSearchResults)
+	}
+	fmt.Fprintf(w, "   ✅ %d identical\n", result.Summary.Identical)
 	if result.Summary.NotMigrated > 0 {
-		fmt.Printf("   ⚠️  %d not migrated (only in old)\n", result.Summary.NotMigrated)
-		for _, change := range result.Changes {
-			if change.Type == "notMigrated" {
-				fmt.Printf("       • %s\n", change.Identifier)
-			}
-		}
+		fmt.Fprintf(w, "   ⚠️  %d not migrated (only in old)\n", result.Summary.NotMigrated)
 	}
-	fmt.Printf("   📝 %d changed\n", result.Summary.Changed)
-	if result.Summary.Orphaned > 0 {
-		fmt.Printf("   ❌ %d orphaned (only in new)\n", result.Summary.Orphaned)
-		for _, change := range result.Changes {
-			if change.Type == "orphaned" {
-				fmt.Printf("       • %s\n", change.Identifier)
-			}
-		}
-	}
-	fmt.Println()
+	fmt.Fprintf(w, "   📝 %d changed\n", result.Summary.Changed)
+	fmt.Fprintln(w)
 }
 
-// PrintDetailedDiffs prints detailed property diffs for changed entities
-func (s *Service) PrintDetailedDiffs(changes []models.EntityChange, limit int) {
-	// Count changed entities
-	changedCount := 0
-	for _, change := range changes {
-		if change.Type == "changed" {
-			changedCount++
-		}
-	}
+// PrintDetailedDiffs writes detailed property diffs for changed entities and
+// the identifiers of not-migrated entities to w. limit caps each section
+// independently; pass <= 0 for unlimited.
+func (s *Service) PrintDetailedDiffs(w io.Writer, result *models.DiffResult, limit int) {
+	printChangedSection(w, result.Changed, limit)
+	printNotMigratedSection(w, result.NotMigrated, limit)
+}
 
-	if changedCount == 0 {
+func printChangedSection(w io.Writer, changed []models.EntityChange, limit int) {
+	if len(changed) == 0 {
 		return
 	}
 
-	fmt.Println("📋 Changed Entities (showing first " + fmt.Sprintf("%d", limit) + "):")
-	fmt.Println()
+	header := "📋 Changed Entities"
+	if limit > 0 && len(changed) > limit {
+		fmt.Fprintf(w, "%s (showing first %d):\n\n", header, limit)
+	} else {
+		fmt.Fprintf(w, "%s:\n\n", header)
+	}
 
 	shown := 0
-	for _, change := range changes {
-		if change.Type != "changed" {
-			continue
-		}
-
-		if shown >= limit {
-			fmt.Printf("⏭️  Showing %d of %d changed entities. Use --limit to show more.\n", limit, changedCount)
+	for _, change := range changed {
+		if limit > 0 && shown >= limit {
+			fmt.Fprintf(w, "⏭️  Showing %d of %d changed entities. Use --limit to show more, or --output to dump the full list to a file.\n", limit, len(changed))
 			break
 		}
-
 		if shown > 0 {
-			fmt.Println()
+			fmt.Fprintln(w)
 		}
-
-		fmt.Printf("  • %s\n", change.Identifier)
-		// Flatten nested diffs into dot-notation paths
-		flatDiffs := flattenDiffs(change.PropertyDiffs)
-		for _, path := range flatDiffs {
-			fmt.Printf("    - %s: %v\n", path.Path, path.OldValue)
-			fmt.Printf("    + %s: %v\n", path.Path, path.NewValue)
+		fmt.Fprintf(w, "  • %s\n", change.Identifier)
+		for _, path := range flattenDiffs(change.PropertyDiffs) {
+			fmt.Fprintf(w, "    - %s: %v\n", path.Path, path.OldValue)
+			fmt.Fprintf(w, "    + %s: %v\n", path.Path, path.NewValue)
 		}
 		shown++
 	}
 
-	fmt.Println()
+	fmt.Fprintln(w)
+}
+
+func printNotMigratedSection(w io.Writer, notMigrated []string, limit int) {
+	if len(notMigrated) == 0 {
+		return
+	}
+
+	header := "⚠️  Not Migrated (only in old)"
+	if limit > 0 && len(notMigrated) > limit {
+		fmt.Fprintf(w, "%s (showing first %d):\n\n", header, limit)
+	} else {
+		fmt.Fprintf(w, "%s:\n\n", header)
+	}
+
+	shown := 0
+	for _, id := range notMigrated {
+		if limit > 0 && shown >= limit {
+			fmt.Fprintf(w, "⏭️  Showing %d of %d not-migrated entities. Use --limit to show more, or --output to dump the full list to a file.\n", limit, len(notMigrated))
+			break
+		}
+		fmt.Fprintf(w, "  • %s\n", id)
+		shown++
+	}
+
+	fmt.Fprintln(w)
 }
 
 // Helper functions
 
-func entitiesEqual(e1, e2 port.Entity, excluded map[string]bool) bool {
+func entitiesEqual(e1, e2 port.Entity) bool {
 	// Compare title
 	if e1.Title != e2.Title {
 		return false
 	}
 
 	// Compare properties (excluding specific fields)
-	m1 := filterProperties(e1.Properties, excluded)
-	m2 := filterProperties(e2.Properties, excluded)
-
-	if !reflect.DeepEqual(m1, m2) {
+	if !reflect.DeepEqual(e1.Properties, e2.Properties) {
 		return false
 	}
 
@@ -193,17 +273,7 @@ func entitiesEqual(e1, e2 port.Entity, excluded map[string]bool) bool {
 	return reflect.DeepEqual(e1.Relations, e2.Relations)
 }
 
-func filterProperties(props map[string]interface{}, excluded map[string]bool) map[string]interface{} {
-	result := make(map[string]interface{})
-	for k, v := range props {
-		if !excluded[k] {
-			result[k] = v
-		}
-	}
-	return result
-}
-
-func getPropertyDiffs(e1, e2 port.Entity, excluded map[string]bool) map[string]models.PropertyDiff {
+func getPropertyDiffs(e1, e2 port.Entity) map[string]models.PropertyDiff {
 	diffs := make(map[string]models.PropertyDiff)
 
 	// Check title
@@ -214,12 +284,9 @@ func getPropertyDiffs(e1, e2 port.Entity, excluded map[string]bool) map[string]m
 		}
 	}
 
-	m1 := filterProperties(e1.Properties, excluded)
-	m2 := filterProperties(e2.Properties, excluded)
-
 	// Check e1 properties
-	for k, v1 := range m1 {
-		v2, exists := m2[k]
+	for k, v1 := range e1.Properties {
+		v2, exists := e2.Properties[k]
 		if !exists || !reflect.DeepEqual(v1, v2) {
 			diffs["properties."+k] = models.PropertyDiff{
 				OldValue: v1,
@@ -229,8 +296,8 @@ func getPropertyDiffs(e1, e2 port.Entity, excluded map[string]bool) map[string]m
 	}
 
 	// Check e2 properties for new fields
-	for k, v2 := range m2 {
-		if _, exists := m1[k]; !exists {
+	for k, v2 := range e2.Properties {
+		if _, exists := e1.Properties[k]; !exists {
 			diffs["properties."+k] = models.PropertyDiff{
 				OldValue: nil,
 				NewValue: v2,
@@ -247,13 +314,6 @@ func getPropertyDiffs(e1, e2 port.Entity, excluded map[string]bool) map[string]m
 	}
 
 	return diffs
-}
-
-func entityToMap(e port.Entity) map[string]interface{} {
-	data, _ := json.Marshal(e)
-	var m map[string]interface{}
-	json.Unmarshal(data, &m)
-	return m
 }
 
 func repeatString(s string, count int) string {

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -8,19 +8,24 @@ import (
 
 	"github.com/port-labs/port-github-migrator/internal/models"
 	"github.com/port-labs/port-github-migrator/internal/port"
+	"github.com/port-labs/port-github-migrator/internal/store"
 )
 
 // Migrator orchestrates the migration process
 type Migrator struct {
 	client *port.Client
 	config *models.Config
+	store  *store.Store // optional; nil disables manifest-based migration
 }
 
-// NewMigrator creates a new migrator
-func NewMigrator(client *port.Client, config *models.Config) *Migrator {
+// NewMigrator creates a new migrator. If `st` is non-nil, blueprint manifests
+// produced by `get-diff` are honored (the migrator patches exactly the
+// captured identifiers and removes the manifest on success).
+func NewMigrator(client *port.Client, config *models.Config, st *store.Store) *Migrator {
 	return &Migrator{
 		client: client,
 		config: config,
+		store:  st,
 	}
 }
 
@@ -45,10 +50,12 @@ func (m *Migrator) Migrate(newDatasourceID string, blueprintID *string, dryRun b
 	// Show warning and get confirmation
 	fmt.Println()
 	fmt.Println("⚠️  WARNING: This action cannot be undone!")
-	fmt.Println("    Please verify your data with 'dry-run' before proceeding.")
+	fmt.Println("    Please verify your data with 'get-diff' and 'dry-run' before proceeding.")
+	fmt.Printf("    Only the first %d entities per blueprint will be migrated.\n", port.MaxSearchResults)
 	fmt.Println()
 
 	totalEntities := 0
+	totalAvailable := 0
 	blueprintCounts := make(map[string]int)
 
 	// Count entities for each blueprint via the cheap aggregate endpoint.
@@ -58,10 +65,19 @@ func (m *Migrator) Migrate(newDatasourceID string, blueprintID *string, dryRun b
 			return nil, fmt.Errorf("failed to count entities for blueprint %s: %w", bp, err)
 		}
 		blueprintCounts[bp] = count
-		totalEntities += count
+		totalAvailable += count
+		if count > port.MaxSearchResults {
+			totalEntities += port.MaxSearchResults
+		} else {
+			totalEntities += count
+		}
 	}
 
-	fmt.Printf("📊 Total entities affected: %d\n", totalEntities)
+	if totalEntities < totalAvailable {
+		fmt.Printf("📊 Total entities affected: %d / %d (capped at %d per blueprint)\n", totalEntities, totalAvailable, port.MaxSearchResults)
+	} else {
+		fmt.Printf("📊 Total entities affected: %d\n", totalEntities)
+	}
 
 	if totalEntities == 0 {
 		fmt.Println("⚠️  No entities found to migrate. Exiting.")
@@ -92,7 +108,11 @@ func (m *Migrator) Migrate(newDatasourceID string, blueprintID *string, dryRun b
 			continue
 		}
 
-		fmt.Printf("\n🔄 Migrating %d entities from blueprint: %s\n", total, bp)
+		if total > port.MaxSearchResults {
+			fmt.Printf("\n🔄 Migrating %d / %d entities from blueprint: %s\n", port.MaxSearchResults, total, bp)
+		} else {
+			fmt.Printf("\n🔄 Migrating %d entities from blueprint: %s\n", total, bp)
+		}
 
 		if !dryRun {
 			if err := m.migrateBlueprint(bp, newDatasourceID); err != nil {
@@ -116,26 +136,25 @@ func (m *Migrator) Migrate(newDatasourceID string, blueprintID *string, dryRun b
 	return stats, nil
 }
 
-// migrateBlueprint migrates a single blueprint
+// migrateBlueprint migrates a single blueprint. The set of identifiers to
+// patch comes either from a previously persisted manifest (e.g. produced by
+// `get-diff`) or from a live search; in both cases it is persisted to the
+// cache before patching so users can audit the exact list, and the manifest
+// is removed on full success.
 func (m *Migrator) migrateBlueprint(blueprintID, newDatasourceID string) error {
-	// Get old entities
-	entities, err := m.client.SearchOldEntitiesByBlueprint(blueprintID, m.config.OldInstallationID)
+	identifiers, manifestPath, err := m.resolveIdentifiers(blueprintID)
 	if err != nil {
-		return fmt.Errorf("failed to search entities: %w", err)
+		return err
 	}
 
-	if len(entities) == 0 {
+	if len(identifiers) == 0 {
 		fmt.Println("⏭️  No entities to migrate")
 		return nil
 	}
 
-	// Extract identifiers
-	identifiers := make([]string, len(entities))
-	for i, entity := range entities {
-		identifiers[i] = entity.Identifier
-	}
+	printIdentifierPreview(identifiers, manifestPath)
 
-	// Patch in batches of 20
+	// Patch in batches of 20.
 	batchSize := 20
 	for i := 0; i < len(identifiers); i += batchSize {
 		end := i + batchSize
@@ -151,6 +170,64 @@ func (m *Migrator) migrateBlueprint(blueprintID, newDatasourceID string) error {
 		fmt.Printf("✅ Successfully patched %d entities\n", len(batch))
 	}
 
+	if m.store != nil {
+		_ = m.store.DeleteIdentifiers(m.config.OldInstallationID, blueprintID)
+	}
+
 	return nil
+}
+
+// resolveIdentifiers returns the entity identifiers to migrate for a
+// blueprint, plus the path of the file backing them (empty if the store was
+// unavailable). It loads an existing identifier cache when present, otherwise
+// it runs a live search and persists the result so the snapshot is stable
+// across retries.
+func (m *Migrator) resolveIdentifiers(blueprintID string) ([]string, string, error) {
+	if m.store != nil {
+		if cached, err := m.store.LoadIdentifiers(m.config.OldInstallationID, blueprintID); err != nil {
+			fmt.Printf("⚠️  Could not read identifiers cache for %s: %v (falling back to live search)\n", blueprintID, err)
+		} else if cached != nil {
+			return cached, m.store.ManifestPath(m.config.OldInstallationID, blueprintID), nil
+		}
+	}
+
+	entities, err := m.client.SearchOldEntitiesByBlueprint(blueprintID, m.config.OldInstallationID, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to search entities: %w", err)
+	}
+
+	identifiers := make([]string, len(entities))
+	for i, entity := range entities {
+		identifiers[i] = entity.Identifier
+	}
+
+	var path string
+	if m.store != nil {
+		p, err := m.store.SaveIdentifiers(m.config.OldInstallationID, blueprintID, identifiers)
+		if err != nil {
+			fmt.Printf("⚠️  Could not save identifiers cache for %s: %v\n", blueprintID, err)
+		} else {
+			path = p
+		}
+	}
+
+	return identifiers, path, nil
+}
+
+// printIdentifierPreview shows the first few identifiers and points the user
+// at the manifest file (if any) for the full list, so we never spam stdout
+// with thousands of identifiers.
+func printIdentifierPreview(identifiers []string, manifestPath string) {
+	const previewN = 5
+	preview := identifiers
+	if len(preview) > previewN {
+		preview = preview[:previewN]
+	}
+	fmt.Printf("📋 First %d of %d identifiers: %s\n", len(preview), len(identifiers), strings.Join(preview, ", "))
+	if manifestPath != "" {
+		fmt.Printf("   Full list: %s\n", manifestPath)
+	} else if len(identifiers) > previewN {
+		fmt.Printf("   ... and %d more\n", len(identifiers)-previewN)
+	}
 }
 

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -19,34 +19,42 @@ type MigrationStats struct {
 	Errors            []string
 }
 
-// DiffResult holds the comparison results
+// DiffResult holds the comparison results. Changed and NotMigrated are kept
+// as disjoint slices so callers (renderers, the auto-mode result file, etc.)
+// don't have to demux a tagged type at every read site.
+//
+// Only source-side totals are tracked: the target blueprint is just a
+// reference oracle for the diff (it tells us the desired state for the
+// source identifiers we're comparing) and its overall size is irrelevant
+// to migration decisions.
 type DiffResult struct {
-	SourceBlueprint string
-	TargetBlueprint string
-	Summary         DiffSummary
-	Changes         []EntityChange
+	SourceBlueprint   string         `json:"sourceBlueprint"`
+	TargetBlueprint   string         `json:"targetBlueprint"`
+	SourceTotal       int            `json:"sourceTotal"` // true total available in old install
+	SourceCompared    int            `json:"sourceCompared"`
+	SourceIdentifiers []string       `json:"sourceIdentifiers,omitempty"` // identifiers actually compared on the source side
+	Summary           DiffSummary    `json:"summary"`
+	Changed           []EntityChange `json:"changed"`     // entities present in both with property differences
+	NotMigrated       []string       `json:"notMigrated"` // identifiers present only in the source
 }
 
 // DiffSummary holds summary statistics
 type DiffSummary struct {
-	Identical   int
-	NotMigrated int
-	Changed     int
-	Orphaned    int
+	Identical   int `json:"identical"`
+	NotMigrated int `json:"notMigrated"`
+	Changed     int `json:"changed"`
 }
 
-// EntityChange represents a single entity difference
+// EntityChange represents an entity that exists on both sides with differing
+// properties. Use DiffResult.NotMigrated for entities missing from the target.
 type EntityChange struct {
-	Identifier   string
-	Type         string // "identical", "changed", "notMigrated", "orphaned"
-	OldEntity    map[string]interface{}
-	NewEntity    map[string]interface{}
-	PropertyDiffs map[string]PropertyDiff
+	Identifier    string                  `json:"identifier"`
+	PropertyDiffs map[string]PropertyDiff `json:"propertyDiffs,omitempty"`
 }
 
 // PropertyDiff represents a single property difference
 type PropertyDiff struct {
-	OldValue interface{}
-	NewValue interface{}
+	OldValue interface{} `json:"oldValue"`
+	NewValue interface{} `json:"newValue"`
 }
 

--- a/internal/port/client.go
+++ b/internal/port/client.go
@@ -12,7 +12,13 @@ import (
 	"time"
 )
 
-const maxRetries = 3
+const (
+	maxRetries = 3
+
+	// MaxSearchResults caps the number of entities returned by a single
+	// searchEntitiesByBlueprint call when SearchOptions.EnforceTotalLimit is true.
+	MaxSearchResults = 5000
+)
 
 // Client handles all Port API interactions
 type Client struct {
@@ -31,9 +37,7 @@ type AuthResponse struct {
 }
 
 // Integration represents a Port integration / installation as returned by
-// GET /v1/integration/{installationId}. Config holds the integration's
-// mapping config which we inspect for guardrails such as
-// `entityDeletionThreshold` before migrating.
+// GET /v1/integration/{installationId}.
 type Integration struct {
 	Version string         `json:"version"`
 	Config  map[string]any `json:"config"`
@@ -84,7 +88,34 @@ type BulkPatchRequest struct {
 	Datasource          string   `json:"datasource"`
 }
 
-// NewClient creates a new Port API client
+type Blueprint struct {
+	Identifier string `json:"identifier"`
+	Schema struct {
+		Properties map[string]any `json:"properties"`
+	} `json:"schema"`
+	Relations map[string]any `json:"relations"`
+}
+
+type BlueprintResponse struct {
+	Blueprint Blueprint `json:"blueprint"`
+}
+
+type SearchOptions struct {
+	IncludeTitle bool
+    IncludeProperties bool
+    IncludeRelations  bool
+    EnforceTotalLimit bool
+}
+
+func DefaultSearchOptions() SearchOptions {
+    return SearchOptions{
+        IncludeTitle: true,
+        IncludeProperties: true,
+        IncludeRelations:  true,
+        EnforceTotalLimit: true,
+    }
+}
+
 func NewClient(baseURL, clientID, clientSecret string) *Client {
 	return &Client{
 		baseURL:      strings.TrimSuffix(baseURL, "/"),
@@ -140,9 +171,6 @@ func (c *Client) getToken() (string, error) {
 	return c.fetchAccessToken()
 }
 
-// doAuthorizedRequest performs an authorized request and retries on transient
-// failures (network errors, 429, 5xx). 401 is handled inside attemptWithAuth
-// by refreshing the access token and retrying once.
 func (c *Client) doAuthorizedRequest(method, url string, body []byte, contentType string) (*http.Response, error) {
 	var lastErr error
 
@@ -178,8 +206,6 @@ func (c *Client) doAuthorizedRequest(method, url string, body []byte, contentTyp
 	return nil, fmt.Errorf("request failed after %d retries: %w", maxRetries, lastErr)
 }
 
-// attemptWithAuth performs a single request, transparently refreshing the
-// access token and retrying once on 401.
 func (c *Client) attemptWithAuth(method, url string, body []byte, contentType string) (*http.Response, error) {
 	do := func() (*http.Response, error) {
 		var r io.Reader
@@ -217,14 +243,13 @@ func (c *Client) attemptWithAuth(method, url string, body []byte, contentType st
 	return resp, nil
 }
 
+// backoff returns an exponential backoff duration with jitter for retry loops.
 func backoff(attempt int) time.Duration {
 	base := time.Duration(1<<attempt) * time.Second
 	jitter := time.Duration(rand.Int63n(int64(500 * time.Millisecond)))
 	return base + jitter
 }
 
-// retryAfter parses an x-ratelimit-reset / Retry-After header. It accepts
-// either a delta-seconds integer or an HTTP-date.
 func retryAfter(h string) time.Duration {
 	if h == "" {
 		return 0
@@ -241,8 +266,7 @@ func retryAfter(h string) time.Duration {
 }
 
 // GetIntegration fetches the full integration (version + config) for the
-// given installation. The Config map is required by callers that need to
-// enforce mapping-level guardrails such as `entityDeletionThreshold`.
+// given installation.
 func (c *Client) GetIntegration(installationID string) (*Integration, error) {
 	resp, err := c.doAuthorizedRequest(
 		"GET",
@@ -318,65 +342,148 @@ func (c *Client) GetBlueprintsByDataSource(installationID string) ([]string, err
 	return result, nil
 }
 
-// searchEntitiesByBlueprint searches for entities with optional query
-func (c *Client) searchEntitiesByBlueprint(blueprintID string, query map[string]interface{}) ([]Entity, error) {
+// GetBlueprint fetches a blueprint by identifier
+func (c *Client) GetBlueprint(blueprintID string) (*Blueprint, error) {
+	resp, err := c.doAuthorizedRequest(
+		"GET",
+		fmt.Sprintf("%s/v1/blueprints/%s", c.baseURL, blueprintID),
+		nil,
+		"",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("get blueprint failed: %s", string(body))
+	}
+
+	var bpResp BlueprintResponse
+	if err := json.NewDecoder(resp.Body).Decode(&bpResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &bpResp.Blueprint, nil
+}
+
+// httpPageSize is the maximum number of entities the search endpoint returns
+// per HTTP request. Higher-level batching (auto mode) is built on top of this.
+const httpPageSize = 1000
+
+// searchPageRequest captures everything the search endpoint needs to produce
+// one HTTP page so callers can paginate at different granularities.
+type searchPageRequest struct {
+	blueprintID string
+	query       map[string]any
+	include     []string
+	from        string
+}
+
+// fetchSearchPage performs a single search HTTP call and returns the entities
+// plus the cursor for the next page (empty when exhausted).
+func (c *Client) fetchSearchPage(req searchPageRequest) ([]Entity, string, error) {
+	reqBody := map[string]any{
+		"limit":   httpPageSize,
+		"include": req.include,
+	}
+	if req.query != nil {
+		reqBody["query"] = req.query
+	}
+	if req.from != "" {
+		reqBody["from"] = req.from
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, "", err
+	}
+
+	searchURL := fmt.Sprintf("%s/v1/blueprints/%s/entities/search", c.baseURL, req.blueprintID)
+	resp, err := c.doAuthorizedRequest("POST", searchURL, bodyBytes, "application/json")
+	if err != nil {
+		return nil, "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, "", fmt.Errorf("search failed: %s", string(body))
+	}
+
+	var searchResp SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&searchResp); err != nil {
+		return nil, "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return searchResp.Entities, searchResp.Next, nil
+}
+
+// resolveIncludes builds the include list (identifier + title + properties +
+// relations) that the search endpoint needs based on the blueprint schema.
+func (c *Client) resolveIncludes(blueprintID string, opts SearchOptions) ([]string, error) {
+	bp, err := c.GetBlueprint(blueprintID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch blueprint %s: %w", blueprintID, err)
+	}
+
+	include := []string{"$identifier"}
+	if opts.IncludeTitle {
+		include = append(include, "$title")
+	}
+	if opts.IncludeProperties {
+		for k := range bp.Schema.Properties {
+			include = append(include, k)
+		}
+	}
+	if opts.IncludeRelations {
+		for k := range bp.Relations {
+			include = append(include, k)
+		}
+	}
+	return include, nil
+}
+
+func (c *Client) searchEntitiesByBlueprint(blueprintID string, query map[string]any, options *SearchOptions) ([]Entity, error) {
+	opts := DefaultSearchOptions()
+	if options != nil {
+		opts = *options
+	}
+
+	include, err := c.resolveIncludes(blueprintID, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	allEntities := []Entity{}
-	limit := 200
 	var next string
-	searchURL := fmt.Sprintf("%s/v1/blueprints/%s/entities/search", c.baseURL, blueprintID)
-
 	for {
-		reqBody := map[string]interface{}{
-			"limit": limit,
-		}
-
-		if query != nil {
-			reqBody["query"] = query
-		}
-
-		if next != "" {
-			reqBody["from"] = next
-		}
-
-		bodyBytes, err := json.Marshal(reqBody)
+		page, nextCursor, err := c.fetchSearchPage(searchPageRequest{
+			blueprintID: blueprintID,
+			query:       query,
+			include:     include,
+			from:        next,
+		})
 		if err != nil {
 			return nil, err
 		}
 
-		resp, err := c.doAuthorizedRequest("POST", searchURL, bodyBytes, "application/json")
-		if err != nil {
-			return nil, fmt.Errorf("request failed: %w", err)
-		}
+		allEntities = append(allEntities, page...)
 
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			return nil, fmt.Errorf("search failed: %s", string(body))
-		}
-
-		var searchResp SearchResponse
-		if err := json.NewDecoder(resp.Body).Decode(&searchResp); err != nil {
-			resp.Body.Close()
-			return nil, fmt.Errorf("failed to decode response: %w", err)
-		}
-		resp.Body.Close()
-
-		allEntities = append(allEntities, searchResp.Entities...)
-
-		if searchResp.Next == "" {
+		if nextCursor == "" || (opts.EnforceTotalLimit && len(allEntities) >= MaxSearchResults) {
 			break
 		}
-
-		next = searchResp.Next
+		next = nextCursor
 	}
 
 	return allEntities, nil
 }
 
-func oldGitHubAppEntityQuery(oldInstallationID string) map[string]interface{} {
-	return map[string]interface{}{
+func oldGitHubAppEntityQuery(oldInstallationID string) map[string]any {
+	return map[string]any{
 		"combinator": "and",
-		"rules": []map[string]interface{}{
+		"rules": []map[string]any{
 			{
 				"property": "$datasource",
 				"operator": "contains",
@@ -391,51 +498,59 @@ func oldGitHubAppEntityQuery(oldInstallationID string) map[string]interface{} {
 	}
 }
 
-// SearchOldEntitiesByBlueprint searches for old GitHub App entities
-func (c *Client) SearchOldEntitiesByBlueprint(blueprintID, oldInstallationID string) ([]Entity, error) {
-	return c.searchEntitiesByBlueprint(blueprintID, oldGitHubAppEntityQuery(oldInstallationID))
-}
-
-// newGitHubOceanEntityQuery returns the search filter used to locate entities
-// owned by the new GitHub Ocean installation.
-func newGitHubOceanEntityQuery(newInstallationID string) map[string]interface{} {
-	return map[string]interface{}{
-		"combinator": "and",
-		"rules": []map[string]interface{}{
-			{
-				"property": "$datasource",
-				"operator": "contains",
-				"value":    "port-ocean/github-ocean",
-			},
-			{
-				"property": "$datasource",
-				"operator": "contains",
-				"value":    fmt.Sprintf("%s/exporter", newInstallationID),
-			},
+func newGitHubOceanEntityQuery(newInstallationID string, oldIdentifiers []string) map[string]any {
+	rules := []map[string]any{
+		{
+			"property": "$datasource",
+			"operator": "contains",
+			"value":    "port-ocean/github-ocean",
 		},
+		{
+			"property": "$datasource",
+			"operator": "contains",
+			"value":    fmt.Sprintf("%s/exporter", newInstallationID),
+		},
+	}
+
+	if oldIdentifiers != nil {
+		rules = append(rules, map[string]any{
+			"property": "$identifier",
+			"operator": "in",
+			"value":    oldIdentifiers,
+		})
+	}
+
+	return map[string]any{
+		"combinator": "and",
+		"rules":      rules,
 	}
 }
 
-// SearchNewEntitiesByBlueprint searches for new GitHub Ocean entities
-func (c *Client) SearchNewEntitiesByBlueprint(blueprintID, newInstallationID string) ([]Entity, error) {
-	return c.searchEntitiesByBlueprint(blueprintID, newGitHubOceanEntityQuery(newInstallationID))
+// SearchOldEntitiesByBlueprint searches for old GitHub App entities
+func (c *Client) SearchOldEntitiesByBlueprint(blueprintID, oldInstallationID string, options *SearchOptions) ([]Entity, error) {
+	return c.searchEntitiesByBlueprint(blueprintID, oldGitHubAppEntityQuery(oldInstallationID), options)
 }
 
-// GroupCount represents a single bucket returned by the entities/group endpoint.
+// SearchNewEntitiesByBlueprint searches for new GitHub Ocean entities
+func (c *Client) SearchNewEntitiesByBlueprint(blueprintID, newInstallationID string, oldIdentifiers []string, options *SearchOptions) ([]Entity, error) {
+	return c.searchEntitiesByBlueprint(blueprintID, newGitHubOceanEntityQuery(newInstallationID, oldIdentifiers), options)
+}
+
+// GroupCount represents a single bucket returned by the entities/group endpoint
 type GroupCount struct {
 	Value string `json:"value"`
 	Count int    `json:"count"`
 }
 
-// GroupResponse represents the response of the entities/group endpoint.
+// GroupResponse represents the response of the entities/group endpoint
 type GroupResponse struct {
 	Groups        []GroupCount `json:"groups"`
 	HasMoreGroups bool         `json:"hasMoreGroups"`
 }
 
-// CountEntitiesByBlueprint returns the total number of entities matching
-// `query` in a blueprint, using the entities/group aggregate endpoint. This
-// is much cheaper than paginating /entities/search just to count.
+// CountEntitiesByBlueprint returns the total number of entities matching `query`
+// in a blueprint, using the entities/group aggregate endpoint. This is much
+// cheaper than paginating /entities/search just to count.
 func (c *Client) CountEntitiesByBlueprint(blueprintID string, query map[string]interface{}) (int, error) {
 	body := map[string]any{
 		"query": query,
@@ -476,14 +591,14 @@ func (c *Client) CountEntitiesByBlueprint(blueprintID string, query map[string]i
 	return gr.Groups[0].Count, nil
 }
 
-// CountOldEntitiesByBlueprint counts entities ingested by the old GitHub App installation.
+// CountOldEntitiesByBlueprint counts entities ingested by the old GitHub App installation
 func (c *Client) CountOldEntitiesByBlueprint(blueprintID, oldInstallationID string) (int, error) {
 	return c.CountEntitiesByBlueprint(blueprintID, oldGitHubAppEntityQuery(oldInstallationID))
 }
 
-// CountNewEntitiesByBlueprint counts entities ingested by the new GitHub Ocean installation.
+// CountNewEntitiesByBlueprint counts entities ingested by the new GitHub Ocean installation
 func (c *Client) CountNewEntitiesByBlueprint(blueprintID, newInstallationID string) (int, error) {
-	return c.CountEntitiesByBlueprint(blueprintID, newGitHubOceanEntityQuery(newInstallationID))
+	return c.CountEntitiesByBlueprint(blueprintID, newGitHubOceanEntityQuery(newInstallationID, nil))
 }
 
 // PatchEntitiesDatasourceBulk updates entities' datasource in bulk

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,114 @@
+// Package store persists per-blueprint identifier lists under the user's
+// cache directory so that `migrate` can act on the exact set of entities that
+// `get-diff` compared, even across separate invocations.
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	appDir         = "port-github-migrator"
+	blueprintsDir  = "blueprints"
+	manifestSuffix = ".json"
+
+	// cacheTTL is how long a saved identifier list is considered fresh. After
+	// this window, LoadIdentifiers treats the file as missing so callers do a
+	// fresh fetch against Port instead of acting on a stale snapshot.
+	cacheTTL = 10 * time.Minute
+)
+
+// cacheMetadata is the on-disk shape of a cache file: a creation
+// timestamp for TTL enforcement plus the identifier list itself.
+type cacheMetadata struct {
+	CreatedAt   time.Time `json:"createdAt"`
+	Identifiers []string  `json:"identifiers"`
+}
+
+// Store is a small wrapper around the on-disk cache directory.
+type Store struct {
+	root string
+}
+
+// Open returns a Store rooted at <UserCacheDir>/port-github-migrator/. The
+// directory is not created until the first write.
+func Open() (*Store, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve user cache dir: %w", err)
+	}
+	return &Store{root: filepath.Join(base, appDir)}, nil
+}
+
+// Root returns the on-disk directory backing this store.
+func (s *Store) Root() string { return s.root }
+
+// ManifestPath returns the absolute path that the identifier list for the
+// given (oldInstallationID, blueprint) is stored at. Lists are namespaced by
+// old installation id so that concurrent migrations of different integrations
+// do not collide.
+func (s *Store) ManifestPath(oldInstallID, bp string) string {
+	return filepath.Join(s.root, blueprintsDir, oldInstallID, bp+manifestSuffix)
+}
+
+// SaveIdentifiers writes (or overwrites) the identifier list for
+// (oldInstallID, bp) and returns the file path it was written to. The file
+// embeds the creation timestamp so that stale reads can be detected.
+func (s *Store) SaveIdentifiers(oldInstallID, bp string, identifiers []string) (string, error) {
+	if oldInstallID == "" || bp == "" {
+		return "", errors.New("oldInstallID and blueprint are required")
+	}
+
+	path := s.ManifestPath(oldInstallID, bp)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("failed to create cache dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(cacheMetadata{
+		CreatedAt:   time.Now().UTC(),
+		Identifiers: identifiers,
+	}, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// LoadIdentifiers returns the saved identifier list for (oldInstallID, bp).
+// Returns (nil, nil) when no file exists OR when the cached entry is older
+// than cacheTTL — callers should treat both as a cache miss and fetch fresh.
+func (s *Store) LoadIdentifiers(oldInstallID, bp string) ([]string, error) {
+	data, err := os.ReadFile(s.ManifestPath(oldInstallID, bp))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var c cacheMetadata
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("failed to parse identifier list %s: %w", bp, err)
+	}
+	if time.Since(c.CreatedAt) > cacheTTL {
+		return nil, nil
+	}
+	return c.Identifiers, nil
+}
+
+// DeleteIdentifiers removes a blueprint's identifier file. It's a no-op if
+// the file is already gone.
+func (s *Store) DeleteIdentifiers(oldInstallID, bp string) error {
+	if err := os.Remove(s.ManifestPath(oldInstallID, bp)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -99,6 +99,7 @@ func (s *Store) LoadIdentifiers(oldInstallID, bp string) ([]string, error) {
 		return nil, fmt.Errorf("failed to parse identifier list %s: %w", bp, err)
 	}
 	if time.Since(c.CreatedAt) > cacheTTL {
+		_ = os.Remove(s.ManifestPath(oldInstallID, bp))
 		return nil, nil
 	}
 	return c.Identifiers, nil


### PR DESCRIPTION
## Summary

- Introduced a local manifest cache under `<UserCacheDir>/port-github-migrator/blueprints/` so `migrate` patches exactly the identifiers `get-diff` captured, with a 10-min TTL and automatic fallback to a live search if the cache is stale
- Enforced the 5000-entity-per-blueprint cap on all search calls (`EnforceTotalLimit`) — `migrate` now shows capped counts (`N / total`) in its preflight summary and per-blueprint progress when a blueprint exceeds the limit; `get-diff` output suggests using `--output` when the display is capped
- Added capped indication to `migrate --all` blueprint listing (`N / total` when a blueprint exceeds the limit)

## Test plan

- [ ] `get-diff <src> <tgt>` followed by `migrate <src>` — patches exactly the cached identifiers, no extra live search
- [ ] Stale manifest (>10 min old) is ignored — migrate falls back to a live search
- [ ] Blueprint with >5000 entities shows `5000 / <total>` in `migrate` preflight output and the `--all` listing
- [ ] `get-diff --output result.json` writes the full result; terminal output caps with a suggestion to use `--output`

## Port

- Task: [task_tei2l4](https://app.port.io/taskEntity?identifier=task_tei2l4)
- Parent: [task_te8xcf — Github migration tool improvements](https://app.port.io/taskEntity?identifier=task_te8xcf)

Stacks on **PR #6**.