### PR TITLE
migrate --auto for unattended bulk migration

### DIFF
--- a/cmd/commands/migrate.go
+++ b/cmd/commands/migrate.go
@@ -13,13 +13,17 @@ import (
 
 func NewMigrateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "migrate [blueprint]",
+		Use:          "migrate [sourceBlueprint] [targetBlueprint]",
 		Short:        "Migrate Ownership of entities from a specific blueprint or all blueprints",
 		Long: `Migrate Ownership of entities from the old GitHub App integration to the new GitHub Ocean integration.
 
-When run for a single blueprint, migrate honors the manifest produced by
-'get-diff' if one exists for the same old installation: it patches exactly
-those identifiers and removes the manifest on success.`,
+Modes:
+  migrate <blueprint>                              Migrate a single blueprint (uses get-diff cache if available).
+  migrate --all                                    Migrate every blueprint reachable from the old installation.
+  migrate <sourceBlueprint> <targetBlueprint> --auto
+                                                   Auto mode: paginate the source blueprint, diff each batch
+                                                   against the target blueprint under the new installation,
+                                                   patch identicals in place, and dump the rest to a result file.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			portURL, _ := cmd.Flags().GetString("port-url")
@@ -29,19 +33,34 @@ those identifiers and removes the manifest on success.`,
 			newInstallID, _ := cmd.Flags().GetString("new-installation-id")
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
 			all, _ := cmd.Flags().GetBool("all")
+			auto, _ := cmd.Flags().GetBool("auto")
 
+			if auto && all {
+				return fmt.Errorf("❌ --auto cannot be combined with --all; auto mode runs against a single source/target blueprint pair")
+			}
+			if auto && len(args) != 2 {
+				return fmt.Errorf("❌ --auto requires both sourceBlueprint and targetBlueprint arguments. Usage: migrate <sourceBlueprint> <targetBlueprint> --auto")
+			}
+			if !auto && len(args) > 1 {
+				return fmt.Errorf("❌ a second blueprint argument is only valid with --auto (source/target pair). Use a single blueprint or --all otherwise")
+			}
 			if len(args) == 0 && !all {
-				return fmt.Errorf("❌ either provide a blueprint name or use --all flag. Usage: migrate <blueprint> or migrate --all")
+				return fmt.Errorf("❌ either provide a blueprint name or use --all flag. Usage: migrate <blueprint> or migrate --all or migrate <sourceBlueprint> <targetBlueprint> --auto")
 			}
 			if len(args) > 0 && all {
 				return fmt.Errorf("❌ cannot use both blueprint argument and --all flag")
 			}
 
 			blueprint := ""
+			targetBlueprint := ""
 			if len(args) > 0 {
 				blueprint = args[0]
 			}
+			if len(args) > 1 {
+				targetBlueprint = args[1]
+			}
 
+			// Validate required parameters
 			var missing []string
 			if clientID == "" {
 				missing = append(missing, "--client-id")
@@ -59,8 +78,11 @@ those identifiers and removes the manifest on success.`,
 				return fmt.Errorf("❌ missing required options: %v", missing)
 			}
 
+			// Create Port client
 			client := port.NewClient(portURL, clientID, clientSecret)
 
+			// Fetch the new integration. We need its version for the datasource id
+			// and its config for the entityDeletionThreshold safety check.
 			intg, err := client.GetIntegration(newInstallID)
 			if err != nil {
 				return fmt.Errorf("failed to get integration: %w", err)
@@ -73,8 +95,10 @@ those identifiers and removes the manifest on success.`,
 				return err
 			}
 
+			// Construct new datasource ID
 			newDatasourceID := fmt.Sprintf("port-ocean/github-ocean/%s/%s/exporter", intg.Version, newInstallID)
 
+			// Create config
 			config := &models.Config{
 				PortAPIURL:        portURL,
 				ClientID:          clientID,
@@ -92,29 +116,49 @@ those identifiers and removes the manifest on success.`,
 
 			mig := migrator.NewMigrator(client, config, st)
 
-			if all {
-				fmt.Fprintln(cmd.OutOrStdout(), "📋 Blueprints to migrate:")
-
-				counts, err := blueprints.FetchCounts(client, oldInstallID, cmd.ErrOrStderr())
-				if err != nil {
-					return err
-				}
-				blueprints.PrintCounts(cmd.OutOrStdout(), counts, false, true)
-				fmt.Fprintln(cmd.OutOrStdout())
+		// Auto mode: paginate the source blueprint, diff each batch against
+		// the target blueprint under the new install, patch identicals in
+		// place, and dump the leftover changed/missing entities to a single
+		// result file under the cache directory.
+		if auto {
+			if st == nil {
+				return fmt.Errorf("❌ --auto requires a writable cache directory; could not open one")
 			}
-
-			var bp *string
-			if !all && blueprint != "" {
-				bp = &blueprint
+			path, err := mig.MigrateAuto(blueprint, targetBlueprint, newDatasourceID, dryRun, cmd.ErrOrStderr())
+			if err != nil {
+				return err
 			}
+			fmt.Fprintf(cmd.OutOrStdout(), "📝 Result file: %s\n", path)
+			return nil
+		}
 
-			_, err = mig.Migrate(newDatasourceID, bp, dryRun)
-			return err
+		// If migrating "all", show blueprints with entity counts first
+		if all {
+			fmt.Fprintln(cmd.OutOrStdout(), "📋 Blueprints to migrate:")
+
+			counts, err := blueprints.FetchCounts(client, oldInstallID, cmd.ErrOrStderr())
+			if err != nil {
+				return err
+			}
+			blueprints.PrintCounts(cmd.OutOrStdout(), counts, false, true)
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+
+		// Determine if migrating single blueprint or all
+		var bp *string
+		if !all && blueprint != "" {
+			bp = &blueprint
+		}
+
+		// Run migration
+		_, err = mig.Migrate(newDatasourceID, bp, dryRun)
+		return err
 		},
 	}
 
 	cmd.Flags().Bool("dry-run", false, "Show what would be migrated without making changes")
 	cmd.Flags().Bool("all", false, "Migrate all blueprints with entities")
+	cmd.Flags().Bool("auto", false, "Auto mode: paginate the source blueprint in batches, diff each batch against the target blueprint under the new install, migrate identical entities, and dump remaining diffs to a result file. Requires <sourceBlueprint> <targetBlueprint> positional args.")
 
 	return cmd
 }
@@ -129,7 +173,7 @@ func requireZeroDeletionThreshold(intg *port.Integration) error {
 
 	raw, ok := intg.Config[key]
 	if !ok {
-		return fmt.Errorf("❌ %s is not set in the new GitHub Ocean integration's mapping config; without it, the next resync may delete migrated entities. %s", key, remediation)
+		return fmt.Errorf("❌ %s is not set in the new GitHub Ocean integration's mapping config; without it, the next resync may delete migrated entities, because it's using the temp blueprint. %s", key, remediation)
 	}
 	n, ok := raw.(float64)
 	if !ok {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/port-labs/port-github-migrator/cmd/commands"
 )
 
-const Version = "v0.0.6"
+const Version = "v0.0.8"
 
 func main() {
 	// Load .env file

--- a/internal/migrator/auto.go
+++ b/internal/migrator/auto.go
@@ -1,0 +1,187 @@
+package migrator
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/port-labs/port-github-migrator/internal/diff"
+	"github.com/port-labs/port-github-migrator/internal/models"
+	"github.com/port-labs/port-github-migrator/internal/port"
+	"github.com/port-labs/port-github-migrator/internal/store"
+)
+
+// autoBatchSize is how many old-installation entities one auto-mode batch
+// processes end-to-end (fetch source -> fetch target -> diff -> patch).
+// Matches port.MaxSearchResults so each batch mirrors what get-diff/migrate
+// would do today.
+const autoBatchSize = port.MaxSearchResults
+
+// autoPatchChunkSize is the number of identifiers per PatchEntitiesDatasourceBulk
+// call. Mirrors migrateBlueprint's chunking.
+const autoPatchChunkSize = 20
+
+// MigrateAuto runs the unattended auto migration for one source -> target
+// blueprint pair: it walks the source blueprint under the old installation in
+// autoBatchSize batches, diffs each batch against the target blueprint under
+// the new installation, patches identical source-blueprint entities to the
+// new datasource, and persists the remaining changed/missing identifiers
+// into a single result file under the cache directory. The path of that
+// file is returned on success.
+//
+// Auto mode requires a working store (we always write a result file). The
+// spinner is rendered to spinnerOut; pass io.Discard to disable it.
+func (m *Migrator) MigrateAuto(sourceBlueprintID, targetBlueprintID, newDatasourceID string, dryRun bool, spinnerOut io.Writer) (string, error) {
+	if m.store == nil {
+		return "", errors.New("auto mode requires a writable cache directory; could not open one")
+	}
+
+	sp := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	sp.Writer = spinnerOut
+	sp.HideCursor = true
+
+	var (
+		stateMu      sync.Mutex
+		currentBatch int
+		phase        string
+	)
+	setSuffix := func(p string) {
+		stateMu.Lock()
+		phase = p
+		sp.Lock()
+		if currentBatch == 0 {
+			sp.Suffix = fmt.Sprintf(" %s", phase)
+		} else {
+			sp.Suffix = fmt.Sprintf(" Batch %d: %s", currentBatch, phase)
+		}
+		sp.Unlock()
+		stateMu.Unlock()
+	}
+	setBatch := func(i int) {
+		stateMu.Lock()
+		currentBatch = i
+		stateMu.Unlock()
+	}
+
+	setSuffix(fmt.Sprintf("counting %s entities (old install)...", sourceBlueprintID))
+	sp.Start()
+	defer sp.Stop()
+
+	totalAvailable, err := m.client.CountOldEntitiesByBlueprint(sourceBlueprintID, m.config.OldInstallationID)
+	if err != nil {
+		return "", fmt.Errorf("failed to count source entities: %w", err)
+	}
+
+	result := store.AutoResult{
+		SourceBlueprint: sourceBlueprintID,
+		TargetBlueprint: targetBlueprintID,
+		GeneratedAt:     time.Now().UTC(),
+		Changed:         []models.EntityChange{},
+		NotMigrated:     []string{},
+	}
+	var totalIdentical, totalProcessed int
+
+	if totalAvailable == 0 {
+		setSuffix("no entities to migrate; writing empty result file...")
+		return m.store.SaveAutoResult(m.config.OldInstallationID, result)
+	}
+
+	processBatch := func(batch []port.Entity, batchIndex int) error {
+		setBatch(batchIndex + 1)
+		setSuffix(fmt.Sprintf("fetching target entities from %s (%d ids)...", targetBlueprintID, len(batch)))
+
+		ids := make([]string, len(batch))
+		for i, e := range batch {
+			ids[i] = e.Identifier
+		}
+
+		targetEntities, err := m.client.SearchNewEntitiesByBlueprint(
+			targetBlueprintID,
+			m.config.NewInstallationID,
+			ids,
+			&port.SearchOptions{
+				IncludeTitle:      true,
+				IncludeProperties: true,
+				IncludeRelations:  true,
+				EnforceTotalLimit: false,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to fetch target entities: %w", err)
+		}
+
+		setSuffix(fmt.Sprintf("diffing %d source vs %d target entities...", len(batch), len(targetEntities)))
+
+		identical, changed, notMigrated := diff.DiffEntities(batch, targetEntities)
+		totalProcessed += len(batch)
+
+		result.Changed = append(result.Changed, changed...)
+		result.NotMigrated = append(result.NotMigrated, notMigrated...)
+		result.Summary.Changed += len(changed)
+		result.Summary.NotMigrated += len(notMigrated)
+
+		if len(identical) == 0 {
+			setSuffix(fmt.Sprintf("no identicals to patch (processed %d/%d)", totalProcessed, totalAvailable))
+			return nil
+		}
+
+		if dryRun {
+			totalIdentical += len(identical)
+			result.Summary.Identical += len(identical)
+			setSuffix(fmt.Sprintf("dry-run: would patch %d identicals (processed %d/%d)", len(identical), totalProcessed, totalAvailable))
+			return nil
+		}
+
+		patched := 0
+		for i := 0; i < len(identical); i += autoPatchChunkSize {
+			end := min(i+autoPatchChunkSize, len(identical))
+			chunk := identical[i:end]
+
+			setSuffix(fmt.Sprintf("patching identicals %d/%d (processed %d/%d)", patched+len(chunk), len(identical), totalProcessed, totalAvailable))
+
+			if err := m.client.PatchEntitiesDatasourceBulk(sourceBlueprintID, chunk, newDatasourceID); err != nil {
+				return fmt.Errorf("failed to patch batch: %w", err)
+			}
+			patched += len(chunk)
+		}
+
+		totalIdentical += patched
+		result.Summary.Identical += patched
+		return nil
+	}
+
+	setSuffix(fmt.Sprintf("fetching source entities from %s (0/%d)...", sourceBlueprintID, totalAvailable))
+	if err := m.client.SearchOldEntitiesPaged(
+		sourceBlueprintID,
+		m.config.OldInstallationID,
+		autoBatchSize,
+		nil,
+		processBatch,
+	); err != nil {
+		return "", err
+	}
+
+	setBatch(0)
+	setSuffix("writing result file...")
+
+	path, err := m.store.SaveAutoResult(m.config.OldInstallationID, result)
+	if err != nil {
+		return "", fmt.Errorf("failed to write result file: %w", err)
+	}
+
+	sp.Stop()
+
+	fmt.Println()
+	if dryRun {
+		fmt.Printf("🔄 DRY RUN: would have patched %d identical entities (%s -> %s)\n", totalIdentical, sourceBlueprintID, targetBlueprintID)
+	} else {
+		fmt.Printf("✅ Patched %d identical entities (%s -> %s)\n", totalIdentical, sourceBlueprintID, targetBlueprintID)
+	}
+	fmt.Printf("📊 Summary: %d identical, %d changed, %d not migrated (%d processed / %d available)\n",
+		result.Summary.Identical, result.Summary.Changed, result.Summary.NotMigrated, totalProcessed, totalAvailable)
+
+	return path, nil
+}

--- a/internal/port/client.go
+++ b/internal/port/client.go
@@ -480,6 +480,75 @@ func (c *Client) searchEntitiesByBlueprint(blueprintID string, query map[string]
 	return allEntities, nil
 }
 
+// SearchOldEntitiesPaged streams old GitHub App entities to `handle` in
+// batches of up to `batchSize` (defaults to MaxSearchResults when <= 0).
+// Unlike SearchOldEntitiesByBlueprint, this method has no overall cap: it
+// walks the cursor until exhausted so auto mode can process every entity.
+// `handle` is invoked synchronously; returning an error aborts iteration.
+func (c *Client) SearchOldEntitiesPaged(
+	blueprintID, oldInstallationID string,
+	batchSize int,
+	options *SearchOptions,
+	handle func(batch []Entity, batchIndex int) error,
+) error {
+	if batchSize <= 0 {
+		batchSize = MaxSearchResults
+	}
+
+	opts := DefaultSearchOptions()
+	if options != nil {
+		opts = *options
+	}
+	opts.EnforceTotalLimit = false
+
+	include, err := c.resolveIncludes(blueprintID, opts)
+	if err != nil {
+		return err
+	}
+
+	query := oldGitHubAppEntityQuery(oldInstallationID)
+
+	var (
+		buffer     []Entity
+		next       string
+		batchIndex int
+		exhausted  bool
+	)
+
+	for !exhausted {
+		page, nextCursor, err := c.fetchSearchPage(searchPageRequest{
+			blueprintID: blueprintID,
+			query:       query,
+			include:     include,
+			from:        next,
+		})
+		if err != nil {
+			return err
+		}
+
+		buffer = append(buffer, page...)
+		next = nextCursor
+		exhausted = nextCursor == ""
+
+		for len(buffer) >= batchSize {
+			batch := buffer[:batchSize]
+			if err := handle(batch, batchIndex); err != nil {
+				return err
+			}
+			batchIndex++
+			buffer = buffer[batchSize:]
+		}
+	}
+
+	if len(buffer) > 0 {
+		if err := handle(buffer, batchIndex); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func oldGitHubAppEntityQuery(oldInstallationID string) map[string]any {
 	return map[string]any{
 		"combinator": "and",

--- a/internal/store/auto.go
+++ b/internal/store/auto.go
@@ -1,0 +1,74 @@
+package store
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/port-labs/port-github-migrator/internal/models"
+)
+
+const autoDir = "auto"
+
+// AutoResult is the on-disk shape of a single auto-mode run's outcome for one
+// (sourceBlueprint -> targetBlueprint) pair: the changed entities (with their
+// property diffs) and the identifiers of entities present in the source
+// blueprint under the old install but missing from the target blueprint
+// under the new install.
+type AutoResult struct {
+	SourceBlueprint string                `json:"sourceBlueprint"`
+	TargetBlueprint string                `json:"targetBlueprint"`
+	GeneratedAt     time.Time             `json:"generatedAt"`
+	Summary         models.DiffSummary    `json:"summary"`
+	Changed         []models.EntityChange `json:"changed"`
+	NotMigrated     []string              `json:"notMigrated"`
+}
+
+// SaveAutoResult writes the result file for an auto-mode run to
+// <root>/auto/<oldInstallID>/migration-result-<uuid>.json and returns the
+// absolute path it was written to.
+func (s *Store) SaveAutoResult(oldInstallID string, r AutoResult) (string, error) {
+	if oldInstallID == "" {
+		return "", errors.New("oldInstallID is required")
+	}
+
+	id, err := newUUIDv4()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate result id: %w", err)
+	}
+
+	dir := filepath.Join(s.root, autoDir, oldInstallID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create auto results dir: %w", err)
+	}
+
+	path := filepath.Join(dir, fmt.Sprintf("migration-result-%s.json", id))
+
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// newUUIDv4 generates an RFC 4122 v4 UUID without pulling in a new dependency.
+func newUUIDv4() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	hexed := hex.EncodeToString(b[:])
+	return fmt.Sprintf("%s-%s-%s-%s-%s", hexed[0:8], hexed[8:12], hexed[12:16], hexed[16:20], hexed[20:32]), nil
+}


### PR DESCRIPTION
## Summary

- Added `migrate <sourceBlueprint> <targetBlueprint> --auto` — paginates the source blueprint in batches of 5000 (no overall cap), diffs each batch against the target blueprint, patches identical entities in-place, and writes the remainder (changed + not-migrated) to a JSON result file under the cache directory
- Skips the interactive confirmation prompt so auto mode is safe for unattended/scripted execution
- Result file path is printed at the end for easy pickup by CI or scripts
- Introduced `SearchOldEntitiesPaged` on the Port client for unbounded iteration (bypasses the `EnforceTotalLimit` cap that regular `migrate` and `get-diff` use)

## Test plan

- [ ] `migrate <src> <tgt> --auto` runs end-to-end, produces `<cache>/auto/<oldInstallID>/migration-result-<uuid>.json`, and patches identicals
- [ ] Result file contains `changed` entries with property diffs and `notMigrated` identifier lists
- [ ] `migrate <src> <tgt> --auto --all` is rejected; `migrate --auto` (no args) is rejected with a descriptive error
- [ ] Spinner reflects per-batch state throughout

## Port

- Task: [task_tei2la](https://app.port.io/taskEntity?identifier=task_tei2la)
- Parent: [task_te8xcf — Github migration tool improvements](https://app.port.io/taskEntity?identifier=task_te8xcf)

Stacks on **PR #7**.